### PR TITLE
Add Crimean Tatar language

### DIFF
--- a/lib/enums/lang_list.dart
+++ b/lib/enums/lang_list.dart
@@ -9,6 +9,8 @@ enum LangListEnum {
   arabic('ar', 'العربية'),
   bulgarian('bg', 'Български'),
   catalan('ca', 'Català'),
+  crimeanTatarLatin('crh-Latn', 'Qırımtatarca'),
+  crimeanTatarCyrillic('crh', 'Къырымтатарджа'),
   croatian('hr', 'Hrvatski'),
   czech('cs', 'Čeština'),
   danish('da', 'Dansk'),


### PR DESCRIPTION
This commit adds the Crimean Tatar language as an option to translate it via Google Translate. Both Latin and Cyrillic variants were added.