### PR TITLE
**Add Linux support for EPUB metadata parsing**

### DIFF
--- a/lib/utils/get_path/get_temp_dir.dart
+++ b/lib/utils/get_path/get_temp_dir.dart
@@ -9,6 +9,7 @@ Future<Directory> getAnxTempDir() async {
     case TargetPlatform.windows:
     case TargetPlatform.macOS:
     case TargetPlatform.iOS:
+    case TargetPlatform.linux: 
       return await getTemporaryDirectory();
     default:
       throw Exception('Unsupported platform');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,6 +96,7 @@ dependencies:
   cached_network_image: ^3.4.1
   lpinyin: ^2.0.3
   mongol: ^9.0.0
+  xml: ^6.4.2
 
 
 dev_dependencies:


### PR DESCRIPTION

# Description
Adds Linux platform support by implementing XML/archive-based EPUB parsing as an alternative to `flutter_inappwebview` (which doesn't support Linux). 

**Changes:**
- Added Linux-specific metadata extraction using `xml` and `archive` packages
- Included Linux platform in `getAnxTempDir()` function
- Fallback parsing extracts title, author, description, and cover from EPUB files

**Dependencies added:**
- `xml: ^6.4.2`


```bash
:~/Documents/GitHub/anx-reader$ flutter pub deps | grep flutter_inappwebview
├── flutter_inappwebview 6.2.0-beta.3
│   ├── flutter_inappwebview_android 1.2.0-beta.3
│   │   └── flutter_inappwebview_platform_interface...
│   ├── flutter_inappwebview_ios 1.2.0-beta.3
│   │   └── flutter_inappwebview_platform_interface...
│   ├── flutter_inappwebview_macos 1.2.0-beta.3
│   │   └── flutter_inappwebview_platform_interface...
│   ├── flutter_inappwebview_platform_interface 1.4.0-beta.3
│   │   ├── flutter_inappwebview_internal_annotations 1.2.0
│   ├── flutter_inappwebview_web 1.2.0-beta.3
│   │   ├── flutter_inappwebview_platform_interface...
│   └── flutter_inappwebview_windows 0.7.0-beta.3
│       └── flutter_inappwebview_platform_interface...
```


