### PR TITLE
fix: fix windows crash when initialize the window position

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,28 +27,21 @@ import 'package:window_manager/window_manager.dart';
 final navigatorKey = GlobalKey<NavigatorState>();
 late AudioHandler audioHandler;
 
+
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Prefs().initPrefs();
-  if (Platform.isWindows) {
-    await windowManager.ensureInitialized();
-    final size = Size(
-      Prefs().windowInfo.width,
-      Prefs().windowInfo.height,
-    );
-    final offset = Offset(
-      Prefs().windowInfo.x,
-      Prefs().windowInfo.y,
-    );
 
-    WindowManager.instance.setTitle('Anx Reader');
-    if (size.width > 0 && size.height > 0) {
-      await WindowManager.instance.setPosition(offset);
-      await WindowManager.instance.setSize(size);
-    }
+
+   if (Platform.isWindows) {
+    await windowManager.ensureInitialized();
+    await WindowManager.instance.setTitle('Anx Reader');
     await WindowManager.instance.show();
     await WindowManager.instance.focus();
   }
+
+
 
   initBasePath();
   AnxLog.init();


### PR DESCRIPTION
fix #432 

目前發現在某些 windows 環境下面會有問題，可能跟螢幕大小、是否雙開螢幕有關，加了 Try catch 也沒法捕捉到，可能是更底層的 error

這個 PR 算是 workaround ，不確定初始到本來的位置對閱讀體驗有多大幫助?

有更好的解法麻煩指教了