### PR TITLE
Upgrade haptic feedback

### DIFF
--- a/lib/service/vibration_service.dart
+++ b/lib/service/vibration_service.dart
@@ -144,7 +144,7 @@ class VibrationService {
     final canUseHaptics = await _safeCanUseHaptics();
     if (canUseHaptics) {
       try {
-        await Haptics.vibrate(type);
+        await Haptics.vibrate(type, usage: HapticsUsage.media);
         return;
       } catch (_) {
         // Fall through to vibration fallback.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1035,10 +1035,10 @@ packages:
     dependency: "direct main"
     description:
       name: haptic_feedback
-      sha256: d3b5ad41858d18a35d317636c9cdc1cb8aef23c7b861ca5896273acc68e1a98a
+      sha256: "3b960570ad094b20028f439a22996f88fadcb20addd49478dbd47db5984a8894"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1+1"
+    version: "0.6.4+2"
   hashcodes:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -121,7 +121,7 @@ dependencies:
     git:
       url: https://github.com/Anxcye/staggered_reorderable.git
       ref: 2ac799a6eeb5da74bf5080a2ba2057272fa52b78
-  haptic_feedback: ^0.5.1+1
+  haptic_feedback: ^0.6.4+2
   in_app_purchase_android: ^0.4.0+8
 
 dependency_overrides:


### PR DESCRIPTION
I saw that this is a popular app using my package `haptic_feedback`.

Recently I've made some substantial improvements which will come with this PR:

- Android 13+ users who have disabled touch haptics in system settings didn't get haptics from the app. This change sets the usage type to `media` (before it was `unknown`, which defaults to `touch`). If vibrations are indeed supposed to be disabled when the user opts out from touch haptics, we can remove the usage argument, or set it to touch.

- On Android 11+ the plugin can now use HD vibrations which feel much better and smoother

- Android 7.* devices now vibrate with the correct pattern

https://pub.dev/packages/haptic_feedback/changelog