### PR TITLE
fix: add isMaximized window info for restoring the state on app startup (Windows)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,12 +40,19 @@ Future<void> main() async {
       Prefs().windowInfo.y,
     );
 
+    final isMaximized = Prefs().windowInfo.isMaximized;
+
     WindowManager.instance.setTitle('Anx Reader');
-    if (size.width > 0 && size.height > 0) {
+
+    if (isMaximized) {
+      await WindowManager.instance.maximize();
+    } else if (size.width > 0 && size.height > 0) {
       await WindowManager.instance.setPosition(offset);
       await WindowManager.instance.setSize(size);
     }
-    await WindowManager.instance.show();
+
+    // await WindowManager.instance.show();
+
     await WindowManager.instance.focus();
   }
 
@@ -108,6 +115,16 @@ class _MyAppState extends ConsumerState<MyApp>
   }
 
   @override
+  Future<void> onWindowMaximize() async {
+    await _updateWindowInfo();
+  }
+
+  @override
+  Future<void> onWindowUnmaximize() async {
+    await _updateWindowInfo();
+  }
+
+  @override
   Future<void> onWindowResized() async {
     await _updateWindowInfo();
   }
@@ -118,12 +135,14 @@ class _MyAppState extends ConsumerState<MyApp>
     }
     final windowOffset = await windowManager.getPosition();
     final windowSize = await windowManager.getSize();
+    final isMaximized = await windowManager.isMaximized();
 
     Prefs().windowInfo = WindowInfo(
       x: windowOffset.dx,
       y: windowOffset.dy,
       width: windowSize.width,
       height: windowSize.height,
+      isMaximized: isMaximized
     );
     AnxLog.info('onWindowClose: Offset: $windowOffset, Size: $windowSize');
   }

--- a/lib/models/window_info.dart
+++ b/lib/models/window_info.dart
@@ -10,6 +10,7 @@ abstract class WindowInfo with _$WindowInfo {
     required double y,
     required double width,
     required double height,
+    @Default(false) bool isMaximized,
   }) = _WindowInfo;
 
   factory WindowInfo.fromJson(Map<String, dynamic> json) =>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1332,10 +1332,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -2093,26 +2093,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -150,7 +150,7 @@ bool Win32Window::Create(const std::wstring& title,
 }
 
 bool Win32Window::Show() {
-  return ShowWindow(window_handle_, SW_SHOWNORMAL);
+  return ShowWindow(window_handle_, SW_SHOW);
 }
 
 // static


### PR DESCRIPTION
While window size and position are saved in persistent `Prefs()`, maximization is not being tracked by the app. This update introduces new property in `WindowInfo` - `isMaximized`, and it's used in app startup.

This update follows the app structure regarding the window size, uses `_updateWindowInfo` method. 

The `win32_window.cpp` now uses `SW_SHOW` property in `ShowWindow()` function, which does not restore the window to non-minimized like `SW_SHOWNORMAL` does. 

Now, when a user maximizes the app window and closes the app, on app opening the window is maximized.  