### PR TITLE
feat: auto-navigate chapters on vertical swipe in scroll page turning method

### DIFF
--- a/assets/foliate-js/src/book.js
+++ b/assets/foliate-js/src/book.js
@@ -1167,7 +1167,22 @@ class Reader {
   }
 
   #onTouchEnd = ({ detail: e }) => {
-    if (this.#ignoreTouch()) return;
+    if (this.#ignoreTouch()) {
+      if (e.touchState.direction === 'vertical') {
+        const renderer = this.view.renderer;
+        const scrollTop = renderer.shadowRoot.querySelector('#container').scrollTop;
+        const deltaY = e.touchState.delta.y;
+        const swipeThreshold = 60;
+
+        if (deltaY > swipeThreshold && scrollTop <= 1) {
+          renderer.shadowRoot.querySelector('#container').scrollTop = 0;
+          prevPage();
+        } else if (deltaY < -swipeThreshold && renderer.viewSize - renderer.end <= 1) {
+          nextPage();
+        }
+        return;
+      }
+    }
 
     const mainView = this.view.shadowRoot.children[0]
     if (e.touchState.direction === 'vertical') {

--- a/lib/page/book_player/epub_player.dart
+++ b/lib/page/book_player/epub_player.dart
@@ -1089,15 +1089,11 @@ class EpubPlayerState extends ConsumerState<EpubPlayer>
               ),
             if (Prefs().openBookAnimation)
               SizedBox.expand(
-                child: Prefs().openBookAnimation
-                    ? IgnorePointer(
-                        ignoring: true,
-                        child: FadeTransition(
-                            opacity: _animation!,
-                            child: BookCover(book: widget.book)),
-                      )
-                    : BookCover(book: widget.book),
-              ),
+                  child: IgnorePointer(
+                ignoring: true,
+                child: FadeTransition(
+                    opacity: _animation!, child: BookCover(book: widget.book)),
+              )),
           ],
         ),
       ),


### PR DESCRIPTION
# Add Automatic Chapter Navigation on Vertical Swipe

## Description

This PR adds automatic chapter navigation when using vertical swipe gestures in scroll mode. Users can now seamlessly transition to the next/previous chapter by swiping up/down at the end/beginning of a chapter, without needing to manually tap on the left or right on the screen.

## Related Issue

#638

## Demo
https://github.com/user-attachments/assets/cebc006c-8290-4e16-b0cc-2db3aa645eec

## Testing

Tested on Android and iOS emulator.