### PR TITLE
feat(database): enable sqflite FFI support for iOS and Windows platforms

### DIFF
--- a/lib/dao/database.dart
+++ b/lib/dao/database.dart
@@ -10,7 +10,7 @@ import 'package:anx_reader/utils/get_path/databases_path.dart';
 import 'package:anx_reader/utils/log/common.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
-// import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 // Current app database version
 const int currentDbVersion = 7;
@@ -132,8 +132,8 @@ class DBHelper {
         );
       case AnxPlatformEnum.ios:
       case AnxPlatformEnum.windows:
-        // sqfliteFfiInit();
-        // var databaseFactory = databaseFactoryFfi;
+        sqfliteFfiInit();
+        databaseFactory = databaseFactoryFfi;
 
         final databasePath = await getAnxDataBasesPath();
         AnxLog.info('Database: database path: $databasePath');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -917,9 +917,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: "464b871cb9360c620eeca32a1aada0afb376bb97"
-      url: "https://github.com/Anxcye/flutter_tts.git"
+      ref: HEAD
+      resolved-ref: baad69ab53df427c7c0b62cc0f49ca698899f6ba
+      url: "https://github.com/LeionTong/flutter_tts.git"
     source: git
     version: "4.2.3"
   flutter_web_plugins:
@@ -1332,10 +1332,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -2093,26 +2093,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,9 +55,9 @@ dependencies:
   sqflite_common_ffi: ^2.3.3
   battery_plus: ^6.2.1
   flutter_tts:
+    # path: ../flutter_tts
     git:
-      url: https://github.com/Anxcye/flutter_tts.git
-      ref: master
+      url: https://github.com/LeionTong/flutter_tts.git
   sticky_headers: ^0.3.0+2
   photo_view: ^0.15.0
   flutter_smart_dialog: ^4.9.8+1


### PR DESCRIPTION
## 变更说明

为 iOS 和 Windows 平台启用了 sqflite FFI 支持，以提升数据库性能和兼容性。

## 主要改动

- 在 `lib/dao/database.dart` 中为 iOS 和 Windows 平台启用了 `sqfliteFfiInit()` 和 `databaseFactoryFfi`
- 更新 `flutter_tts` 依赖到支持自然语音的版本：https://github.com/LeionTong/flutter_tts
  - 依赖：https://github.com/gexgd0419/NaturalVoiceSAPIAdapter ，或者使用我重新构建的版本(支持静默安装)：https://github.com/LeionTong/NaturalVoiceSAPIAdapter

## 测试

- [x] 在 Windows 平台测试通过
- [x] 数据库操作正常

