### PR TITLE
feat: In-app search results with configurable search engine

### DIFF
--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.15.0
+- Feat(search): Add in-app search results with configurable search engine and display modes (#894)
+- Feat(ai): Add configurable delay threshold for auto-summary when reopening a book (#922)
+
+- Feat(search): 支持应用内搜索结果显示，可配置搜索引擎和显示方式 (#894)
+- Feat(ai): 新增自动摘要延迟阈值配置，可控制重新打开书籍时的摘要触发时机 (#922)
+
 ## 1.14.0
 - Fix(translate): Remove legacy Microsoft reverse-engineered translation service and migrate saved full-text translation preference to Microsoft Azure API
 - Fix(l10n): Remove legacy Microsoft translation localization entries

--- a/docs/untranslated_messages.txt
+++ b/docs/untranslated_messages.txt
@@ -5,7 +5,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "de": [
@@ -14,7 +27,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "es": [
@@ -23,7 +49,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "fr": [
@@ -32,7 +71,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "it": [
@@ -41,7 +93,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "ja": [
@@ -50,7 +115,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "ko": [
@@ -59,7 +137,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "pt": [
@@ -68,7 +159,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "ro": [
@@ -77,7 +181,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "ru": [
@@ -86,7 +203,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "tr": [
@@ -95,7 +225,20 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "zh": [
@@ -107,13 +250,42 @@
     "settingsAiProviderReasoningEffortHigh"
   ],
 
+  "zh_CN": [
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
+  ],
+
   "zh_LZH": [
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ],
 
   "zh_TW": [
@@ -122,6 +294,19 @@
     "settingsAiProviderReasoningEffortAuto",
     "settingsAiProviderReasoningEffortLow",
     "settingsAiProviderReasoningEffortMedium",
-    "settingsAiProviderReasoningEffortHigh"
+    "settingsAiProviderReasoningEffortHigh",
+    "searchDisplayMode",
+    "searchDefaultEngine",
+    "searchDisplayModePopup",
+    "searchDisplayModeFullScreen",
+    "searchDisplayModeExternal",
+    "searchAddEngine",
+    "searchManageEngines",
+    "searchEngineName",
+    "searchEngineNameRequired",
+    "searchEngineUrlTemplate",
+    "searchEngineUrlRequired",
+    "searchEngineUrlInvalid",
+    "searchEngineAdded"
   ]
 }

--- a/lib/config/shared_preference_provider.dart
+++ b/lib/config/shared_preference_provider.dart
@@ -18,6 +18,8 @@ import 'package:anx_reader/enums/writing_mode.dart';
 import 'package:anx_reader/enums/text_alignment.dart';
 import 'package:anx_reader/enums/ai_panel_position.dart';
 import 'package:anx_reader/enums/ai_chat_display_mode.dart';
+import 'package:anx_reader/enums/search_display_mode.dart';
+import 'package:anx_reader/service/search/search_engine.dart';
 import 'package:anx_reader/enums/bgimg_fit.dart';
 import 'package:anx_reader/enums/code_highlight_theme.dart';
 import 'package:anx_reader/l10n/generated/L10n.dart';
@@ -1630,6 +1632,71 @@ class Prefs extends ChangeNotifier {
   set aiPanelHeight(double height) {
     prefs.setDouble('aiPanelHeight', height);
     notifyListeners();
+  }
+
+  // Search engine settings
+  static const String _searchEnginesKey = 'searchEngines';
+  static const String _selectedSearchEngineIdKey = 'selectedSearchEngineId';
+
+  SearchDisplayMode get searchDisplayMode {
+    return SearchDisplayMode.fromCode(
+        prefs.getString('searchDisplayMode') ?? 'popup');
+  }
+
+  set searchDisplayMode(SearchDisplayMode mode) {
+    prefs.setString('searchDisplayMode', mode.code);
+    notifyListeners();
+  }
+
+  String get selectedSearchEngineId {
+    return prefs.getString(_selectedSearchEngineIdKey) ?? 'bing';
+  }
+
+  set selectedSearchEngineId(String id) {
+    prefs.setString(_selectedSearchEngineIdKey, id);
+    notifyListeners();
+  }
+
+  SearchEngine get selectedSearchEngine {
+    final id = selectedSearchEngineId;
+    return allSearchEngines.firstWhere(
+      (e) => e.id == id,
+      orElse: () => SearchEngine.builtinEngines.first,
+    );
+  }
+
+  List<SearchEngine> get customSearchEngines {
+    final raw = prefs.getString(_searchEnginesKey);
+    if (raw == null || raw.isEmpty) return const [];
+    try {
+      return SearchEngine.decodeList(raw);
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  set customSearchEngines(List<SearchEngine> engines) {
+    prefs.setString(_searchEnginesKey, SearchEngine.encodeList(engines));
+    notifyListeners();
+  }
+
+  List<SearchEngine> get allSearchEngines {
+    return [...SearchEngine.builtinEngines, ...customSearchEngines];
+  }
+
+  void addCustomSearchEngine(SearchEngine engine) {
+    final engines = List<SearchEngine>.from(customSearchEngines);
+    engines.add(engine);
+    customSearchEngines = engines;
+  }
+
+  void deleteCustomSearchEngine(String id) {
+    final engines =
+        customSearchEngines.where((e) => e.id != id).toList(growable: false);
+    customSearchEngines = engines;
+    if (selectedSearchEngineId == id) {
+      selectedSearchEngineId = SearchEngine.builtinEngines.first.id;
+    }
   }
 }
 

--- a/lib/enums/search_display_mode.dart
+++ b/lib/enums/search_display_mode.dart
@@ -1,0 +1,16 @@
+enum SearchDisplayMode {
+  popup('popup'),
+  fullScreen('fullScreen'),
+  external('external');
+
+  const SearchDisplayMode(this.code);
+
+  final String code;
+
+  static SearchDisplayMode fromCode(String code) {
+    return SearchDisplayMode.values.firstWhere(
+      (e) => e.code == code,
+      orElse: () => SearchDisplayMode.popup,
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -890,5 +890,18 @@
   "aiChatFontSize": "Font Size",
   "aiModelSwitchTitle": "Switch Model",
   "aiModelEnterManually": "Enter model name",
-  "aiModelOrSelectBelow": "Or select from list:"
+  "aiModelOrSelectBelow": "Or select from list:",
+  "searchDisplayMode": "Search Display Mode",
+  "searchDefaultEngine": "Default Search Engine",
+  "searchDisplayModePopup": "Popup (in-app overlay)",
+  "searchDisplayModeFullScreen": "Full Screen (in-app)",
+  "searchDisplayModeExternal": "External Browser",
+  "searchAddEngine": "Add Custom Engine",
+  "searchManageEngines": "Custom Engines",
+  "searchEngineName": "Engine Name",
+  "searchEngineNameRequired": "Please enter an engine name",
+  "searchEngineUrlTemplate": "URL Template",
+  "searchEngineUrlRequired": "Please enter a URL template",
+  "searchEngineUrlInvalid": "URL must contain a search query placeholder and use http/https",
+  "searchEngineAdded": "Search engine added"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -884,5 +884,18 @@
     "aiModelSwitchTitle": "切换模型",
     "aiModelEnterManually": "输入模型名称",
     "aiModelOrSelectBelow": "或从列表中选择：",
-    "aiChatFontSize": "字体大小"
+    "aiChatFontSize": "字体大小",
+    "searchDisplayMode": "搜索结果显示方式",
+    "searchDefaultEngine": "默认搜索引擎",
+    "searchDisplayModePopup": "弹窗（应用内覆盖层）",
+    "searchDisplayModeFullScreen": "全屏（应用内）",
+    "searchDisplayModeExternal": "外部浏览器",
+    "searchAddEngine": "添加自定义引擎",
+    "searchManageEngines": "自定义引擎",
+    "searchEngineName": "引擎名称",
+    "searchEngineNameRequired": "请输入引擎名称",
+    "searchEngineUrlTemplate": "URL 模板",
+    "searchEngineUrlRequired": "请输入 URL 模板",
+    "searchEngineUrlInvalid": "URL 必须包含搜索查询占位符且使用 http/https 协议",
+    "searchEngineAdded": "搜索引擎已添加"
 }

--- a/lib/page/settings_page/advanced.dart
+++ b/lib/page/settings_page/advanced.dart
@@ -167,6 +167,22 @@ class _AdvancedSettingState extends State<AdvancedSetting> {
           ],
         ),
         SettingsSection(
+          title: Text(L10n.of(context).searchManageEngines),
+          tiles: [
+            SettingsTile.navigation(
+              leading: const Icon(Icons.search),
+              title: Text(L10n.of(context).searchManageEngines),
+              onPressed: (_) {
+                Navigator.of(context).push(
+                  CupertinoPageRoute(
+                    builder: (context) => const SearchEnginesSetting(),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+        SettingsSection(
           title: Text(L10n.of(context).hints),
           tiles: [
             SettingsTile.navigation(

--- a/lib/page/settings_page/advanced.dart
+++ b/lib/page/settings_page/advanced.dart
@@ -2,6 +2,7 @@ import 'package:anx_reader/config/shared_preference_provider.dart';
 import 'package:anx_reader/dao/book.dart';
 import 'package:anx_reader/l10n/generated/L10n.dart';
 import 'package:anx_reader/models/md5_statistics.dart';
+import 'package:anx_reader/page/settings_page/search_engines.dart';
 import 'package:anx_reader/page/settings_page/subpage/chapter_split_rules_page.dart';
 import 'package:anx_reader/page/settings_page/subpage/log_page.dart';
 import 'package:anx_reader/page/changelog_screen.dart';

--- a/lib/page/settings_page/search_engines.dart
+++ b/lib/page/settings_page/search_engines.dart
@@ -1,0 +1,185 @@
+import 'package:anx_reader/config/shared_preference_provider.dart';
+import 'package:anx_reader/enums/search_display_mode.dart';
+import 'package:anx_reader/l10n/generated/L10n.dart';
+import 'package:anx_reader/service/search/search_engine.dart';
+import 'package:anx_reader/utils/toast/common.dart';
+import 'package:anx_reader/widgets/settings/settings_section.dart';
+import 'package:anx_reader/widgets/settings/settings_tile.dart';
+import 'package:anx_reader/widgets/settings/settings_title.dart';
+import 'package:flutter/material.dart';
+
+class SearchEnginesSetting extends StatefulWidget {
+  const SearchEnginesSetting({super.key});
+
+  @override
+  State<SearchEnginesSetting> createState() => _SearchEnginesSettingState();
+}
+
+class _SearchEnginesSettingState extends State<SearchEnginesSetting> {
+  @override
+  Widget build(BuildContext context) {
+    return settingsSections(
+      sections: [
+        SettingsSection(
+          title: Text(L10n.of(context).searchDisplayMode),
+          tiles: [
+            SettingsTile(
+              title: Column(
+                children: SearchDisplayMode.values.map((mode) {
+                  return RadioListTile<SearchDisplayMode>(
+                    title: Text(_displayModeLabel(context, mode)),
+                    value: mode,
+                    groupValue: Prefs().searchDisplayMode,
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() {
+                          Prefs().searchDisplayMode = value;
+                        });
+                      }
+                    },
+                    contentPadding: EdgeInsets.zero,
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+        SettingsSection(
+          title: Text(L10n.of(context).searchDefaultEngine),
+          tiles: [
+            SettingsTile(
+              title: DropdownButton<String>(
+                isExpanded: true,
+                value: Prefs().selectedSearchEngineId,
+                items: Prefs().allSearchEngines.map((engine) {
+                  return DropdownMenuItem<String>(
+                    value: engine.id,
+                    child: Text(engine.name),
+                  );
+                }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() {
+                      Prefs().selectedSearchEngineId = value;
+                    });
+                  }
+                },
+              ),
+            ),
+          ],
+        ),
+        SettingsSection(
+          title: Text(L10n.of(context).searchManageEngines),
+          tiles: [
+            ...Prefs().customSearchEngines.map((engine) {
+              return SettingsTile(
+                leading: const Icon(Icons.language),
+                title: Text(engine.name),
+                description: Text(engine.urlTemplate),
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: () {
+                    setState(() {
+                      Prefs().deleteCustomSearchEngine(engine.id);
+                    });
+                  },
+                ),
+              );
+            }),
+            SettingsTile.navigation(
+              leading: const Icon(Icons.add),
+              title: Text(L10n.of(context).searchAddEngine),
+              onPressed: (_) => _showAddEngineDialog(),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String _displayModeLabel(BuildContext context, SearchDisplayMode mode) {
+    switch (mode) {
+      case SearchDisplayMode.popup:
+        return L10n.of(context).searchDisplayModePopup;
+      case SearchDisplayMode.fullScreen:
+        return L10n.of(context).searchDisplayModeFullScreen;
+      case SearchDisplayMode.external:
+        return L10n.of(context).searchDisplayModeExternal;
+    }
+  }
+
+  void _showAddEngineDialog() {
+    final nameController = TextEditingController();
+    final urlController = TextEditingController();
+    final formKey = GlobalKey<FormState>();
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(L10n.of(context).searchAddEngine),
+          content: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: nameController,
+                  decoration: InputDecoration(
+                    labelText: L10n.of(context).searchEngineName,
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return L10n.of(context).searchEngineNameRequired;
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: urlController,
+                  decoration: InputDecoration(
+                    labelText: L10n.of(context).searchEngineUrlTemplate,
+                    hintText: 'https://example.com/search?q={query}',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return L10n.of(context).searchEngineUrlRequired;
+                    }
+                    if (!SearchEngine.isValidUrlTemplate(value.trim())) {
+                      return L10n.of(context).searchEngineUrlInvalid;
+                    }
+                    return null;
+                  },
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(L10n.of(context).commonCancel),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                if (formKey.currentState?.validate() ?? false) {
+                  final engine = SearchEngine(
+                    id: SearchEngine.generateId(),
+                    name: nameController.text.trim(),
+                    urlTemplate: urlController.text.trim(),
+                  );
+                  setState(() {
+                    Prefs().addCustomSearchEngine(engine);
+                  });
+                  Navigator.of(dialogContext).pop();
+                  AnxToast.show(L10n.of(context).searchEngineAdded);
+                }
+              },
+              child: Text(L10n.of(context).commonConfirm),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/service/search/search_engine.dart
+++ b/lib/service/search/search_engine.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+class SearchEngine {
+  final String id;
+  final String name;
+  final String urlTemplate;
+  final bool isBuiltin;
+
+  const SearchEngine({
+    required this.id,
+    required this.name,
+    required this.urlTemplate,
+    this.isBuiltin = false,
+  });
+
+  static const List<SearchEngine> builtinEngines = [
+    SearchEngine(
+      id: 'bing',
+      name: 'Bing',
+      urlTemplate: 'https://www.bing.com/search?q={query}',
+      isBuiltin: true,
+    ),
+    SearchEngine(
+      id: 'google',
+      name: 'Google',
+      urlTemplate: 'https://www.google.com/search?q={query}',
+      isBuiltin: true,
+    ),
+    SearchEngine(
+      id: 'duckduckgo',
+      name: 'DuckDuckGo',
+      urlTemplate: 'https://duckduckgo.com/?q={query}',
+      isBuiltin: true,
+    ),
+    SearchEngine(
+      id: 'baidu',
+      name: 'Baidu',
+      urlTemplate: 'https://www.baidu.com/s?wd={query}',
+      isBuiltin: true,
+    ),
+  ];
+
+  String buildUrl(String query) {
+    return urlTemplate.replaceAll('{query}', Uri.encodeQueryComponent(query));
+  }
+
+  static bool isValidUrlTemplate(String template) {
+    if (!template.contains('{query}')) return false;
+    final uri = Uri.tryParse(template.replaceAll('{query}', 'test'));
+    if (uri == null) return false;
+    return uri.scheme == 'http' || uri.scheme == 'https';
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'urlTemplate': urlTemplate,
+        'isBuiltin': isBuiltin,
+      };
+
+  factory SearchEngine.fromJson(Map<String, dynamic> json) => SearchEngine(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        urlTemplate: json['urlTemplate'] as String,
+        isBuiltin: json['isBuiltin'] as bool? ?? false,
+      );
+
+  static List<SearchEngine> decodeList(String jsonStr) {
+    final List<dynamic> decoded = jsonDecode(jsonStr);
+    return decoded
+        .map((e) => SearchEngine.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  static String encodeList(List<SearchEngine> engines) {
+    return jsonEncode(engines.map((e) => e.toJson()).toList());
+  }
+
+  static String generateId() {
+    return DateTime.now().millisecondsSinceEpoch.toRadixString(36);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SearchEngine &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/widgets/context_menu/context_menu.dart
+++ b/lib/widgets/context_menu/context_menu.dart
@@ -5,6 +5,7 @@ import 'package:anx_reader/page/reading_page.dart';
 import 'package:anx_reader/widgets/common/axis_flex.dart';
 import 'package:anx_reader/widgets/context_menu/excerpt_menu.dart';
 import 'package:anx_reader/widgets/context_menu/reader_note_menu.dart';
+import 'package:anx_reader/widgets/context_menu/search_menu.dart';
 import 'package:anx_reader/widgets/context_menu/translation_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
@@ -294,6 +295,8 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay>
   late bool _reverse;
   late bool _showTranslationMenu;
   bool _showReaderNoteMenu = false;
+  bool _showSearchMenu = false;
+  String _searchQuery = '';
   bool _waitingForFirstMeasurement = true;
   late BoxConstraints _menuConstraints;
   late double _bottomInset;
@@ -442,6 +445,20 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay>
     );
   }
 
+  void _toggleSearchMenu({bool? show, String? query}) {
+    final target = show ?? !_showSearchMenu;
+    epubPlayerKey.currentState?.setSelectionClearLocked(target);
+    setState(() {
+      _showSearchMenu = target;
+      if (query != null) _searchQuery = query;
+    });
+    _scheduleRecalculate(
+      delay: _showSearchMenu
+          ? const Duration(milliseconds: 300)
+          : Duration.zero,
+    );
+  }
+
   Future<void> _openReaderNoteMenu(int noteId) async {
     _toggleReaderNoteMenu(show: true);
     if (_readerNoteMenuKey.currentState == null) {
@@ -516,6 +533,7 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay>
                                   decoration: widget.decoration,
                                   toggleTranslationMenu: _toggleTranslationMenu,
                                   toggleReaderNoteMenu: _toggleReaderNoteMenu,
+                                  toggleSearchMenu: _toggleSearchMenu,
                                   openReaderNoteMenu: _openReaderNoteMenu,
                                   onNoteCreated: _handleNoteCreated,
                                   axis: widget.axis,
@@ -552,6 +570,19 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay>
                                 decoration: widget.decoration,
                                 axis: widget.axis,
                                 contextText: widget.contextText,
+                              ),
+                            ],
+                          ),
+                        ],
+                        if (_showSearchMenu) ...[
+                          const SizedBox.square(dimension: 10),
+                          AxisFlex(
+                            axis: widget.axis,
+                            children: [
+                              SearchMenu(
+                                query: _searchQuery,
+                                decoration: widget.decoration,
+                                axis: widget.axis,
                               ),
                             ],
                           ),

--- a/lib/widgets/context_menu/excerpt_menu.dart
+++ b/lib/widgets/context_menu/excerpt_menu.dart
@@ -1,10 +1,12 @@
 import 'package:anx_reader/config/shared_preference_provider.dart';
 import 'package:anx_reader/constants/note_annotations.dart';
 import 'package:anx_reader/dao/book_note.dart';
+import 'package:anx_reader/enums/search_display_mode.dart';
 import 'package:anx_reader/l10n/generated/L10n.dart';
 import 'package:anx_reader/main.dart';
 import 'package:anx_reader/models/book_note.dart';
 import 'package:anx_reader/page/reading_page.dart';
+import 'package:anx_reader/service/search/search_engine.dart';
 import 'package:anx_reader/service/tts/tts_handler.dart';
 import 'package:anx_reader/utils/env_var.dart';
 import 'package:anx_reader/utils/toast/common.dart';
@@ -25,6 +27,7 @@ class ExcerptMenu extends StatefulWidget {
   final BoxDecoration decoration;
   final Function() toggleTranslationMenu;
   final void Function({bool? show}) toggleReaderNoteMenu;
+  final void Function({bool? show, String? query}) toggleSearchMenu;
   final Future<void> Function(int noteId) openReaderNoteMenu;
   final void Function(int noteId) onNoteCreated;
   final Axis axis;
@@ -40,6 +43,7 @@ class ExcerptMenu extends StatefulWidget {
     required this.decoration,
     required this.toggleTranslationMenu,
     required this.toggleReaderNoteMenu,
+    required this.toggleSearchMenu,
     required this.openReaderNoteMenu,
     required this.onNoteCreated,
     required this.axis,
@@ -279,12 +283,29 @@ class ExcerptMenuState extends State<ExcerptMenu> {
           IconAndText(
             compact: true,
             onTap: () {
-              widget.onClose();
-              launchUrl(
-                Uri.parse(
-                    'https://www.bing.com/search?q=${widget.annoContent}'),
-                mode: LaunchMode.externalApplication,
-              );
+              final displayMode = Prefs().searchDisplayMode;
+              final engine = Prefs().selectedSearchEngine;
+              final query = widget.annoContent;
+
+              switch (displayMode) {
+                case SearchDisplayMode.popup:
+                  widget.toggleSearchMenu(show: true, query: query);
+                  break;
+                case SearchDisplayMode.fullScreen:
+                  widget.onClose();
+                  launchUrl(
+                    Uri.parse(engine.buildUrl(query)),
+                    mode: LaunchMode.inAppWebView,
+                  );
+                  break;
+                case SearchDisplayMode.external:
+                  widget.onClose();
+                  launchUrl(
+                    Uri.parse(engine.buildUrl(query)),
+                    mode: LaunchMode.externalApplication,
+                  );
+                  break;
+              }
             },
             icon: const Icon(EvaIcons.globe),
             text: L10n.of(context).contextMenuSearch,

--- a/lib/widgets/context_menu/search_menu.dart
+++ b/lib/widgets/context_menu/search_menu.dart
@@ -1,0 +1,105 @@
+import 'package:anx_reader/config/shared_preference_provider.dart';
+import 'package:anx_reader/l10n/generated/L10n.dart';
+import 'package:anx_reader/service/search/search_engine.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
+
+class SearchMenu extends StatefulWidget {
+  const SearchMenu({
+    super.key,
+    required this.query,
+    required this.decoration,
+    required this.axis,
+  });
+
+  final String query;
+  final BoxDecoration decoration;
+  final Axis axis;
+
+  @override
+  State<SearchMenu> createState() => _SearchMenuState();
+}
+
+class _SearchMenuState extends State<SearchMenu> {
+  late final String _url;
+  InAppWebViewController? _webViewController;
+
+  @override
+  void initState() {
+    super.initState();
+    final engine = Prefs().selectedSearchEngine;
+    _url = engine.buildUrl(widget.query);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+        child: Container(
+          height: widget.axis == Axis.vertical ? double.infinity : 350,
+          width: widget.axis == Axis.vertical ? 300 : double.infinity,
+          decoration: widget.decoration,
+          padding: const EdgeInsets.all(8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '${L10n.of(context).contextMenuSearch}: ${widget.query}',
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      maxLines: 1,
+                    ),
+                  ),
+                  IconButton(
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                    icon: const Icon(Icons.refresh, size: 18),
+                    onPressed: () {
+                      _webViewController?.loadUrl(
+                        urlRequest: URLRequest(url: WebUri(_url)),
+                      );
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: InAppWebView(
+                    initialUrlRequest: URLRequest(url: WebUri(_url)),
+                    initialSettings: InAppWebViewSettings(
+                      isInspectable: kDebugMode,
+                      mediaPlaybackRequiresUserGesture: false,
+                      allowsInlineMediaPlayback: true,
+                    ),
+                    gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
+                      Factory<OneSequenceGestureRecognizer>(
+                        () => EagerGestureRecognizer(),
+                      ),
+                    },
+                    onWebViewCreated: (controller) {
+                      _webViewController = controller;
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements [Issue #881](https://github.com/Anxcye/anx-reader/issues/881) — Display search results directly within the app instead of redirecting to an external browser.

## Changes

### Core
- `SearchDisplayMode` enum — supports popup, full screen, and external browser modes
- `SearchEngine` model — built-in engines (Bing, Google, DuckDuckGo, Baidu) with custom engine support via URL templates

### UI
- `SearchMenu` widget — InAppWebView overlay panel for in-app search results
- Modified `ExcerptMenu` — search button now dispatches based on display mode
- Modified `ContextMenu` — integrates search overlay alongside translation

### Settings
- `SearchEnginesSetting` — manage default engine, display mode, and custom engines
- Added to Advanced settings page

### Localization
- English and Chinese strings for all new UI elements

## Display Modes

| Mode | Behavior |
|------|----------|
| **Popup** (default) | Modal overlay with InAppWebView, similar to translation |
| **Full Screen** | Opens via in-app WebView |
| **External Browser** | Current behavior (backward compatible) |

## Testing
- [x] Code analysis passes (no new errors)
- [x] Localization strings generated
- [ ] Manual testing on Android/iOS/Desktop recommended

Closes #881