### PR TITLE
feat: allow font size adjustment when Use book styles is enabled

### DIFF
--- a/assets/foliate-js/src/book.js
+++ b/assets/foliate-js/src/book.js
@@ -693,7 +693,7 @@ const getCSS = ({ fontSize,
         ${backgroundImageCSS}
         background-color: transparent !important;
         ${useBookStyles ? '' : `letter-spacing: ${letterSpacing}px;`}
-        ${useBookStyles ? '' : `font-size: ${fontSize}em;`}
+        font-size: ${fontSize}em;
         orphans: 1;  
         widows: 1;
     }

--- a/lib/widgets/reading_page/style_widget.dart
+++ b/lib/widgets/reading_page/style_widget.dart
@@ -288,7 +288,6 @@ class StyleWidgetState extends State<StyleWidget> {
   }
 
   Row fontSizeSlider() {
-    bool enabled = !Prefs().useBookStyles;
     return Row(
       children: [
         IconAndText(
@@ -298,15 +297,13 @@ class StyleWidgetState extends State<StyleWidget> {
         Expanded(
           child: Slider(
             value: bookStyle.fontSize,
-            onChanged: enabled
-                ? (double value) {
-                    setState(() {
-                      bookStyle.fontSize = value;
-                      widget.epubPlayerKey.currentState!.changeStyle(bookStyle);
-                      Prefs().saveBookStyleToPrefs(bookStyle);
-                    });
-                  }
-                : null,
+            onChanged: (double value) {
+              setState(() {
+                bookStyle.fontSize = value;
+                widget.epubPlayerKey.currentState!.changeStyle(bookStyle);
+                Prefs().saveBookStyleToPrefs(bookStyle);
+              });
+            },
             min: 0.5,
             max: 3.0,
             divisions: 25,


### PR DESCRIPTION
## Problem

When "Use book styles" is enabled, the font size slider becomes disabled. Font size is a fundamental reading comfort feature that should always be adjustable, since epub embedded font sizes are often unreliable across platforms.

## Solution
Remove the useBookStyles guard from font-size in the html selector. 

## What changed

- `book.js`: `font-size` now always applied to `html` element
- `style_widget.dart`: font size slider no longer disabled