### PR TITLE
feat(ai): show user prompts on home AI tab

### DIFF
--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
 ## 1.15.0
+- Feat(ai): Make custom user prompts available in the Home AI tab for parity with reader AI (#853)
 - Feat(network): Add global HTTP proxy support in advanced settings (#838) Thanks @dddXzz
 - Feat(network): Add HTTP proxy connectivity test feature (#838) Thanks @dddXzz
 - Fix(reader): Fix Android selection auto-page turn — continuous turns and missed turns when dragging across pages (#875) Thanks @addtion99
 - Fix(l10n): Update Russian translation (#874) Thanks @Xapitonov
 
+- Feat(ai): 让自定义用户提示词在首页 AI 标签页中可用，并与阅读器 AI 保持一致 (#853)
 - Feat(network): 新增全局 HTTP 代理支持，可在高级设置中配置代理服务器地址和端口 (#838) 感谢 @dddXzz
 - Feat(network): 新增代理连接测试功能 (#838) 感谢 @dddXzz
 - Fix(reader): 修复 Android 选区跨页自动翻页的连续翻页与漏翻问题 (#875) 感谢 @addtion99

--- a/lib/page/home_page/ai_page.dart
+++ b/lib/page/home_page/ai_page.dart
@@ -1,3 +1,4 @@
+import 'package:anx_reader/service/ai/quick_prompt_chips.dart';
 import 'package:anx_reader/widgets/ai/ai_chat_stream.dart';
 import 'package:flutter/material.dart';
 
@@ -7,8 +8,10 @@ class AiPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: const Center(
-        child: AiChatStream(),
+      body: Center(
+        child: AiChatStream(
+          quickPromptChips: buildDefaultAiQuickPromptChips(context),
+        ),
       ),
     );
   }

--- a/lib/service/ai/quick_prompt_chips.dart
+++ b/lib/service/ai/quick_prompt_chips.dart
@@ -1,0 +1,36 @@
+import 'package:anx_reader/config/shared_preference_provider.dart';
+import 'package:anx_reader/l10n/generated/L10n.dart';
+import 'package:anx_reader/models/ai_quick_prompt_chip.dart';
+import 'package:anx_reader/models/user_prompt.dart';
+import 'package:anx_reader/service/ai/prompt_generate.dart';
+import 'package:flutter/material.dart';
+import 'package:icons_plus/icons_plus.dart';
+
+List<AiQuickPromptChip> buildDefaultAiQuickPromptChips(BuildContext context) {
+  final List<UserPrompt> userPrompts = Prefs().userPrompts;
+
+  return [
+    AiQuickPromptChip(
+      icon: EvaIcons.book,
+      label: L10n.of(context).settingsAiPromptSummaryTheChapter,
+      prompt: generatePromptSummaryTheChapter().buildString(),
+    ),
+    AiQuickPromptChip(
+      icon: Icons.menu_book_rounded,
+      label: L10n.of(context).settingsAiPromptSummaryTheBook,
+      prompt: generatePromptSummaryTheBook().buildString(),
+    ),
+    AiQuickPromptChip(
+      icon: Icons.account_tree_outlined,
+      label: L10n.of(context).settingsAiPromptMindmap,
+      prompt: generatePromptMindmap().buildString(),
+    ),
+    ...userPrompts.where((prompt) => prompt.enabled).map(
+          (prompt) => AiQuickPromptChip(
+            icon: Icons.person_outline,
+            label: prompt.name,
+            prompt: prompt.content,
+          ),
+        ),
+  ];
+}


### PR DESCRIPTION
## Summary
- Make enabled custom user prompts available in the Home AI tab
- Reuse the same quick prompt chip builder as reader AI
- Update changelog for #853

Fixes #853

## Validation
- flutter analyze --no-pub lib/page/home_page/ai_page.dart lib/service/ai/quick_prompt_chips.dart