### PR TITLE
fix(bookshelf): show book file format in details

### DIFF
--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
 ## 1.15.0
+- Fix(bookshelf): Show book file format in detail metadata so users can see the extension inside the app (#910)
 - Feat(network): Add global HTTP proxy support in advanced settings (#838) Thanks @dddXzz
 - Feat(network): Add HTTP proxy connectivity test feature (#838) Thanks @dddXzz
 - Fix(reader): Fix Android selection auto-page turn — continuous turns and missed turns when dragging across pages (#875) Thanks @addtion99
 - Fix(l10n): Update Russian translation (#874) Thanks @Xapitonov
 
+- Fix(bookshelf): 在书籍详情元数据中显示文件格式，方便用户在应用内查看扩展名 (#910)
 - Feat(network): 新增全局 HTTP 代理支持，可在高级设置中配置代理服务器地址和端口 (#838) 感谢 @dddXzz
 - Feat(network): 新增代理连接测试功能 (#838) 感谢 @dddXzz
 - Fix(reader): 修复 Android 选区跨页自动翻页的连续翻页与漏翻问题 (#875) 感谢 @addtion99

--- a/docs/untranslated_messages.txt
+++ b/docs/untranslated_messages.txt
@@ -1,5 +1,6 @@
 {
   "ar": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -23,6 +24,7 @@
   ],
 
   "de": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -46,6 +48,7 @@
   ],
 
   "es": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -69,6 +72,7 @@
   ],
 
   "fr": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -92,6 +96,7 @@
   ],
 
   "it": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -115,6 +120,7 @@
   ],
 
   "ja": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -138,6 +144,7 @@
   ],
 
   "ko": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -161,6 +168,7 @@
   ],
 
   "pt": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -184,6 +192,7 @@
   ],
 
   "ro": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -207,6 +216,7 @@
   ],
 
   "ru": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -230,6 +240,7 @@
   ],
 
   "tr": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -262,6 +273,7 @@
   ],
 
   "zh_LZH": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",
@@ -285,6 +297,7 @@
   ],
 
   "zh_TW": [
+    "bookDetailFileFormat",
     "settingsAiProviderReasoningEffort",
     "settingsAiProviderReasoningEffortHelp",
     "settingsAiProviderReasoningEffortAuto",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -152,6 +152,7 @@
   "bookDetailNthBook": "{count, plural, one{1st book you've read} =2{2nd book you've read} few{3rd book you've read} other{{count}th book you've read}}",
   "bookDetailLastReadDate": "Last read: ",
   "bookDetailImportDate": "Import date: ",
+  "bookDetailFileFormat": "Format: ",
   "readingPageReadingInfo": "Reading Info",
   "readingPageReadingInfoChapterTitle": "Chapter Title",
   "readingPageReadingInfoBattery": "Battery",

--- a/lib/l10n/app_zh-CN.arb
+++ b/lib/l10n/app_zh-CN.arb
@@ -152,6 +152,7 @@
   "bookDetailNthBook": "{count, plural, other{第{count}本读的书}}",
   "bookDetailLastReadDate": "上次阅读",
   "bookDetailImportDate": "首次导入",
+  "bookDetailFileFormat": "文件格式：",
   "readingPageReadingInfo": "阅读信息",
   "readingPageReadingInfoChapterTitle": "章节标题",
   "readingPageReadingInfoBattery": "电量",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -152,6 +152,7 @@
   "bookDetailNthBook": "{count, plural, other{第{count}本读的书}}",
   "bookDetailLastReadDate": "上次阅读",
   "bookDetailImportDate": "首次导入",
+  "bookDetailFileFormat": "文件格式：",
   "readingPageReadingInfo": "阅读信息",
   "readingPageReadingInfoChapterTitle": "章节标题",
   "readingPageReadingInfoBattery": "电量",

--- a/lib/page/book_detail.dart
+++ b/lib/page/book_detail.dart
@@ -29,6 +29,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as path;
 
 class BookDetail extends ConsumerStatefulWidget {
   const BookDetail({super.key, required this.book});
@@ -46,6 +47,14 @@ class _BookDetailState extends ConsumerState<BookDetail> {
   bool _isCollapsed = false;
   final TextEditingController _newTagController = TextEditingController();
   Color? _pendingTagColor;
+
+  String get _bookFileFormat {
+    final extension = path.extension(_book.filePath).replaceFirst('.', '');
+    if (extension.isEmpty) {
+      return '-';
+    }
+    return extension.toUpperCase();
+  }
 
   @override
   void initState() {
@@ -749,6 +758,10 @@ class _BookDetailState extends ConsumerState<BookDetail> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  Text(
+                    '${L10n.of(context).bookDetailFileFormat}$_bookFileFormat',
+                    style: textStyle,
+                  ),
                   Text(
                     '${L10n.of(context).bookDetailImportDate}${widget.book.createTime.toString().substring(0, 10)}',
                     style: textStyle,


### PR DESCRIPTION
## Summary
- Show the book file format in the book detail metadata
- Add localized label for the new metadata row
- Update changelog for #910

Fixes #910

## Validation
- flutter gen-l10n
- flutter analyze --no-pub lib/page/book_detail.dart (reports existing analyzer issues in this file unrelated to this change)