### PR TITLE
Add Linux release builds

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -1,0 +1,51 @@
+name: Build Linux
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      flutter_version:
+        required: true
+        type: string
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ inputs.flutter_version }}
+          cache: true
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake libgtk-3-dev ninja-build pkg-config
+
+      - name: Build Linux bundle
+        run: |
+          flutter config --enable-linux-desktop
+          flutter pub get
+          flutter gen-l10n
+          dart run build_runner build --delete-conflicting-outputs
+          flutter build linux --release
+
+      - name: Package Linux bundle
+        run: |
+          tar -C build/linux/x64/release/bundle \
+            -cJf build/linux/Anx-Reader-linux-x64-${{ inputs.version }}.tar.xz .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-artifacts
+          path: build/linux/*.tar.xz
+          if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,13 @@ jobs:
       flutter_version: ${{ needs.setup.outputs.flutter_version }}
       xcode_version: ${{ needs.setup.outputs.xcode_version }}
 
+  build-linux:
+    needs: setup
+    uses: ./.github/workflows/build-linux.yaml
+    with:
+      version: ${{ needs.setup.outputs.version }}
+      flutter_version: ${{ needs.setup.outputs.flutter_version }}
+
   build-appstore:
     needs: setup
     uses: ./.github/workflows/build-appstore.yaml
@@ -85,8 +92,8 @@ jobs:
       KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
 
   release:
-    # needs: [setup, build-android, build-ios, build-windows, build-macos, build-appstore, build-playstore]
-    needs: [setup, build-android, build-ios, build-windows, build-macos, build-appstore]
+    # needs: [setup, build-android, build-ios, build-windows, build-macos, build-linux, build-appstore, build-playstore]
+    needs: [setup, build-android, build-ios, build-windows, build-macos, build-linux, build-appstore]
     uses: ./.github/workflows/release.yaml
     with:
       tag: ${{ needs.setup.outputs.tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,7 @@ jobs:
             artifacts/windows-artifacts/*.exe
             artifacts/macos-artifacts/*.dmg
             artifacts/macos-artifacts/*.zip
+            artifacts/linux-artifacts/*.tar.xz
             artifacts/ios-artifacts/*.ipa
             artifacts/ios-artifacts/*.zip
           body: ${{ inputs.release_notes }}

--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ Want to build Anx Reader from source? Please follow these steps:
 - Run `dart run build_runner build --delete-conflicting-outputs` to generate the Riverpod code.
 - Run `flutter run` to launch the application.
 
+### Linux
+
+The Linux desktop build uses GTK 3 and CMake. Install your distribution's GTK 3
+development package, CMake, Ninja, pkg-config, and a C/C++ compiler first. Use
+the Flutter version recorded in `.github/flutter-version`, then run:
+
+```sh
+flutter config --enable-linux-desktop
+flutter pub get
+flutter gen-l10n
+dart run build_runner build --delete-conflicting-outputs
+flutter build linux --release
+```
+
+The runnable bundle is written to `build/linux/x64/release/bundle/`.
+
 You may encounter Flutter version incompatibility issues. Please refer to the [Flutter documentation](https://flutter.dev/docs/get-started/install).
 
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -115,4 +115,20 @@ QQ群：1042905699
 - 运行 `dart run build_runner build --delete-conflicting-outputs` 生成 Riverpod 代码。
 - 运行 `flutter run` 启动应用。
 
+### Linux
+
+Linux 桌面端依赖 GTK 3 和 CMake。请先安装发行版提供的 GTK 3 开发包、CMake、
+Ninja、pkg-config 以及 C/C++ 编译器；Flutter 版本请使用 `.github/flutter-version`
+中记录的版本。随后运行：
+
+```sh
+flutter config --enable-linux-desktop
+flutter pub get
+flutter gen-l10n
+dart run build_runner build --delete-conflicting-outputs
+flutter build linux --release
+```
+
+可运行的 bundle 位于 `build/linux/x64/release/bundle/`。
+
 您可能遇到 Flutter 版本不兼容的问题，请参考 [Flutter 文档](https://flutter.dev/docs/get-started/install)。


### PR DESCRIPTION
## Summary

- add a reusable GitHub Actions workflow that builds an x86_64 Linux release bundle
- publish the resulting `.tar.xz` alongside the existing platform artifacts
- document the Linux prerequisites and reproducible release-build commands

## Why

The project already contains a Linux Flutter runner, but tagged releases do not build or publish a Linux artifact. Building from a source archive also requires localization and generated Riverpod/Freezed code before the Linux bundle can compile.

This adds the missing CI and release path without changing third-party dependencies.

Closes #486.

## Validation

- `mise exec flutter@3.35.3 -- flutter pub get`
- `mise exec flutter@3.35.3 -- flutter gen-l10n`
- `mise exec flutter@3.35.3 -- dart run build_runner build --delete-conflicting-outputs`
- `mise exec flutter@3.35.3 -- flutter build linux --release`
- `mise exec flutter@3.35.3 -- flutter analyze --no-fatal-infos --no-fatal-warnings`
