### PR TITLE
fix(ai): avoid native WebView2 crash in book_content_search on Windows

### DIFF
--- a/lib/page/book_player/epub_player.dart
+++ b/lib/page/book_player/epub_player.dart
@@ -317,6 +317,16 @@ class EpubPlayerState extends ConsumerState<EpubPlayer>
     ''');
   }
 
+  Future<void> runAiBookSearch(String keyword) async {
+    ref.read(tocSearchProvider.notifier).start(keyword);
+    final escaped = jsonEncode(keyword);
+    await webViewController.evaluateJavascript(source: 'clearSearch()');
+    await webViewController.evaluateJavascript(
+      source:
+        'search($escaped, {"scope":"book","matchCase":false,"matchDiacritics":false,"matchWholeWords":false})',
+    );
+  }
+
   void _clearSearchHighlights() {
     webViewController.evaluateJavascript(source: "clearSearch()");
   }

--- a/lib/service/ai/tools/ai_tool_registry.dart
+++ b/lib/service/ai/tools/ai_tool_registry.dart
@@ -33,7 +33,7 @@ class AiToolContext {
   late final NotesRepository notesRepository = NotesRepository();
   late final BooksRepository booksRepository = BooksRepository();
   late final BookContentSearchRepository bookContentSearchRepository =
-      BookContentSearchRepository(booksRepository: booksRepository);
+      BookContentSearchRepository(booksRepository: booksRepository, ref: ref);
   late final GroupsRepository groupsRepository = GroupsRepository();
   late final ReadingHistoryRepository readingHistoryRepository =
       ReadingHistoryRepository();

--- a/lib/service/ai/tools/repository/book_content_search_repository.dart
+++ b/lib/service/ai/tools/repository/book_content_search_repository.dart
@@ -3,7 +3,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:anx_reader/models/book.dart';
+import 'package:anx_reader/page/book_player/epub_player.dart';
 import 'package:anx_reader/page/home_page.dart';
+import 'package:anx_reader/page/reading_page.dart';
+import 'package:anx_reader/providers/current_reading.dart';
+import 'package:anx_reader/providers/toc_search.dart';
 import 'package:anx_reader/service/ai/tools/input/book_content_search_input.dart';
 import 'package:anx_reader/service/ai/tools/repository/books_repository.dart';
 import 'package:anx_reader/service/book_player/book_player_server.dart';
@@ -13,9 +17,11 @@ import 'package:anx_reader/utils/webView/webview_console_message.dart';
 import 'package:anx_reader/utils/webView/anx_headless_webview.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class BookContentSearchRepository {
   BookContentSearchRepository({
+    required this.ref,
     BooksRepository? booksRepository,
     Duration? searchTimeout,
     Duration? sessionIdleTimeout,
@@ -23,6 +29,7 @@ class BookContentSearchRepository {
         _searchTimeout = searchTimeout ?? const Duration(seconds: 15),
         _sessionIdleTimeout = sessionIdleTimeout ?? const Duration(minutes: 3);
 
+  final WidgetRef ref;
   final BooksRepository _booksRepository;
   final Duration _searchTimeout;
   final Duration _sessionIdleTimeout;
@@ -38,6 +45,28 @@ class BookContentSearchRepository {
     final book = await _resolveBook(input.bookId);
     AnxLog.info(
         'BookContentSearchRepository: Starting search for book=${book.id}, keyword="$keyword"');
+
+    if (Platform.isWindows) {
+      final playerState = epubPlayerKey.currentState;
+      final currentBookId = ref.read(currentReadingProvider).book?.id;
+      if (playerState != null && currentBookId == book.id) {
+        AnxLog.info('BookContentSearchRepository: using live reader search '
+            '(Windows, book=${book.id} is currently open)');
+        return _runLiveReaderSearch(
+          playerState: playerState,
+          book: book,
+          keyword: keyword,
+          maxResults: input.resolvedMaxResults(),
+          maxSnippets: input.resolvedMaxSnippets(),
+          maxCharacters: input.resolvedMaxCharacters(),
+        );
+      }
+      throw StateError(
+        'book_content_search is unavailable on Windows for books that are not '
+        'currently open in the reader (native WebView2 limitation). '
+        'Open book id=${book.id} ("${book.title}") and retry.',
+      );
+    }
 
     final session = await _getOrCreateSession(book);
 
@@ -76,6 +105,66 @@ class BookContentSearchRepository {
         _sessions.remove(book.id);
       }
     }
+  }
+
+  Future<Map<String, dynamic>> _runLiveReaderSearch({
+    required EpubPlayerState playerState,
+    required Book book,
+    required String keyword,
+    required int maxResults,
+    required int maxSnippets,
+    required int? maxCharacters,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+    try {
+      await playerState.runAiBookSearch(keyword);
+      final completed =
+          await _waitForTocSearchComplete(timeout: _searchTimeout);
+      stopwatch.stop();
+
+      final results = ref.read(tocSearchProvider).results;
+      final mapped = results
+          .take(maxResults)
+          .map((result) => _SearchResult(
+                chapterTitle: result.label,
+                chapterCfi: result.cfi,
+                matches: result.subitems
+                    .take(maxSnippets)
+                    .map((sub) => _SearchMatch(
+                          cfi: sub.cfi,
+                          pre: _SearchMatch._sanitizeSnippet(
+                              sub.pre, maxCharacters),
+                          match: _SearchMatch._sanitizeSnippet(
+                              sub.match, maxCharacters),
+                          post: _SearchMatch._sanitizeSnippet(
+                              sub.post, maxCharacters),
+                        ))
+                    .toList(),
+              ))
+          .toList();
+
+      return {
+        'bookId': book.id,
+        'bookTitle': book.title,
+        'keyword': keyword,
+        'results': mapped.map((result) => result.toMap()).toList(),
+        'searchDurationMs': stopwatch.elapsed.inMilliseconds,
+        'completed': completed,
+      };
+    } finally {
+      playerState.clearSearch();
+    }
+  }
+
+  Future<bool> _waitForTocSearchComplete({required Duration timeout}) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (ref.read(tocSearchProvider).progress >= 1.0) {
+        return true;
+      }
+      await Future.delayed(const Duration(milliseconds: 50));
+    }
+    return false;
   }
 
   Future<Book> _resolveBook(int bookId) async {


### PR DESCRIPTION
## Problem

On Windows, invoking the AI `book_content_search` tool crashes the app hard
(native access violation, no Dart exception, the process just dies). It is
reproducible whenever the AI searches the currently-open book. Related:
#844 (P1, open), #888 (closed stale).

## Root cause

`BookContentSearchRepository` serves the search by spinning up a **second**
`HeadlessInAppWebView` that re-loads the book and runs foliate-js `search()`.
On Windows (WebView2), creating a 2nd headless WebView while the reader
WebView is alive triggers a native crash in `flutter_inappwebview`
(upstream issue #2840). The crash is deterministic on affected machines and
is **not** mitigated by giving the 2nd WebView its own
`WebViewEnvironment`/`userDataFolder` — I tested that first (still crashed;
the log showed the dedicated environment being created, then the process
died mid-search with no `completed` event).

## Fix (Option A: reuse the live reader controller)

On Windows, do not create a 2nd WebView. Run the search on the **existing**
reader WebView and collect the results.

- `EpubPlayerState.runAiBookSearch(keyword)` — resets `tocSearchProvider`
  and runs the book-scoped `search()` on the live reader WebView, reusing
  the reader's existing `onSearch` handler (results flow to
  `tocSearchProvider`). Uses `jsonEncode` for safe keyword escaping.
- `BookContentSearchRepository.search()`:
  - On **Windows**, if the target book is the currently-open one, drive
    `runAiBookSearch()` and collect results from `tocSearchProvider` (poll
    until `progress >= 1.0`), then `clearSearch()` to clean up.
  - On **Windows** for a **non-current** book, return a graceful
    `StateError` in the tool result instead of crashing. The AI gets a
    clear message to ask the user to open the book.
  - On **non-Windows**, the existing headless session path is unchanged
    (the native crash is Windows/WebView2-specific).

## Why not fix the plugin / keep the dedicated environment

A separate `WebViewEnvironment` (separate `userDataFolder`) was the first
attempt and **does not help** — the crash happens at 2nd-WebView creation
itself, independent of environment separation. The real fix belongs in the
`flutter_inappwebview` native Windows plugin (#2840); this PR is an
app-level workaround that avoids the 2nd WebView entirely on Windows so the
AI feature works today, with zero behavior change on other platforms.

## Verification

Built and tested on Windows (Flutter 3.35.3, dev build 1.15.0):

- Before: `book_content_search` crashed the app on the first call (log cut
  off mid-search, no `completed` event, process restarted).
- After: ~12 consecutive `book_content_search` calls on the open book,
  all `completed:true` (~1-1.9 s each), real results (CFI + snippets), app
  stayed alive throughout. A search with zero matches returned
  `completed:true` with empty `results` (graceful, no crash).

`flutter analyze` on the changed files: no issues.

## Files

- `lib/page/book_player/epub_player.dart` — add `runAiBookSearch()`.
- `lib/service/ai/tools/repository/book_content_search_repository.dart` —
  Windows live-reader path + graceful fallback; non-Windows unchanged.
- `lib/service/ai/tools/ai_tool_registry.dart` — pass `WidgetRef` to the
  repository (needed to read `tocSearchProvider` / `currentReadingProvider`).

## Notes / limitations

- On Windows, searching a **non-current** book is unavailable (graceful
  error) until the native plugin issue is fixed. Acceptable trade-off vs. a
  hard crash; the common case (AI asked about the book the user is reading)
  works.
- Minor UX side effect: while the AI search runs, the reader's TOC search
  drawer briefly reflects the AI's search (results are cleared on
  completion). Concurrent manual TOC search + AI search on the same book
  could conflict; AI tool calls are normally sequential.